### PR TITLE
Update IJKPlayer

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
@@ -26,6 +26,8 @@
 #import "IJKFFOptions.h"
 #import "IJKSDLGLViewProtocol.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // media meta
 #define k_IJKM_KEY_FORMAT         @"format"
 #define k_IJKM_KEY_DURATION_US    @"duration_us"
@@ -159,3 +161,4 @@ void IJKFFIOStatCompleteDebugCallback(const char *url,
 void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
                                             int64_t read_bytes, int64_t total_size,
                                             int64_t elpased_time, int64_t total_duration));
+NS_ASSUME_NONNULL_END

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
@@ -82,6 +82,8 @@ typedef enum IJKLogLevel {
 
 - (id)initWithContentURLString:(NSString *)aUrlString
         withNotificationCenter:(NSNotificationCenter *)center
+        withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
+  withApplicationStateProvider:(id<IJKThreadSafeApplicationState>)applicationStateProvider
                    withOptions:(IJKFFOptions *)options;
 
 - (id)initWithMoreContent:(NSURL *)aUrl

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.h
@@ -78,6 +78,10 @@ typedef enum IJKLogLevel {
 - (id)initWithContentURLString:(NSString *)aUrlString
                    withOptions:(IJKFFOptions *)options;
 
+- (id)initWithContentURLString:(NSString *)aUrlString
+        withNotificationCenter:(NSNotificationCenter *)center
+                   withOptions:(IJKFFOptions *)options;
+
 - (id)initWithMoreContent:(NSURL *)aUrl
              withOptions:(IJKFFOptions *)options
               withGLView:(UIView<IJKSDLGLViewProtocol> *)glView;
@@ -85,6 +89,8 @@ typedef enum IJKLogLevel {
 - (id)initWithMoreContentString:(NSString *)aUrlString
                  withOptions:(IJKFFOptions *)options
                   withGLView:(UIView<IJKSDLGLViewProtocol> *)glView;
+
+@property (nonatomic, readonly) NSNotificationCenter* videoPlaybackNotificationCenter;
 
 - (void)prepareToPlay;
 - (void)play;

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -609,10 +609,16 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
     int state = ijkmp_get_state(_mediaPlayer);
     switch (state) {
         case MP_STATE_STOPPED:
-        case MP_STATE_COMPLETED:
-        case MP_STATE_ERROR:
-        case MP_STATE_END:
             mpState = IJKMPMoviePlaybackStateStopped;
+            break;
+        case MP_STATE_COMPLETED:
+            mpState = IJKMPMoviePlaybackStateCompleted;
+            break;
+        case MP_STATE_ERROR:
+            mpState = IJKMPMoviePlaybackStateError;
+            break;
+        case MP_STATE_END:
+            mpState = IJKMPMoviePlaybackStateEnd;
             break;
         case MP_STATE_IDLE:
         case MP_STATE_INITIALIZED:
@@ -634,7 +640,10 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
     // IJKMPMoviePlaybackStateStopped,
     // IJKMPMoviePlaybackStateInterrupted,
     // IJKMPMoviePlaybackStateSeekingForward,
-    // IJKMPMoviePlaybackStateSeekingBackward
+    // IJKMPMoviePlaybackStateSeekingBackward,
+    // IJKMPMoviePlaybackStateCompleted,
+    // IJKMPMoviePlaybackStateError,
+    // IJKMPMoviePlaybackStateEnd
     return mpState;
 }
 
@@ -1729,6 +1738,9 @@ static int ijkff_inject_callback(void *opaque, int message, void *data, size_t d
             switch (self.playbackState) {
                 case IJKMPMoviePlaybackStatePaused:
                 case IJKMPMoviePlaybackStateStopped:
+                case IJKMPMoviePlaybackStateCompleted:
+                case IJKMPMoviePlaybackStateError:
+                case IJKMPMoviePlaybackStateEnd:
                     _playingBeforeInterruption = NO;
                     break;
                 default:

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -195,7 +195,6 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 
         // init fields
         _scalingMode = IJKMPMovieScalingModeAspectFit;
-        _shouldAutoplay = YES;
         memset(&_asyncStat, 0, sizeof(_asyncStat));
         memset(&_cacheStat, 0, sizeof(_cacheStat));
         _monitor = [[IJKFFMonitor alloc] init];
@@ -301,7 +300,6 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 
         // init fields
         _scalingMode = IJKMPMovieScalingModeAspectFit;
-        _shouldAutoplay = YES;
         memset(&_asyncStat, 0, sizeof(_asyncStat));
         memset(&_cacheStat, 0, sizeof(_cacheStat));
         _monitor = [[IJKFFMonitor alloc] init];

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -619,8 +619,14 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
             mpState = IJKMPMoviePlaybackStateEnd;
             break;
         case MP_STATE_IDLE:
+            mpState = IJKMPMoviePlaybackStateIdle;
+            break;
         case MP_STATE_INITIALIZED:
+            mpState = IJKMPMoviePlaybackStateInitialized;
+            break;
         case MP_STATE_ASYNC_PREPARING:
+            mpState = IJKMPMoviePlaybackStateAsyncPreparing;
+            break;
         case MP_STATE_PAUSED:
             mpState = IJKMPMoviePlaybackStatePaused;
             break;
@@ -1734,6 +1740,9 @@ static int ijkff_inject_callback(void *opaque, int message, void *data, size_t d
         case AVAudioSessionInterruptionTypeBegan: {
             NSLog(@"IJKFFMoviePlayerController:audioSessionInterrupt: begin\n");
             switch (self.playbackState) {
+                case IJKMPMoviePlaybackStateIdle:
+                case IJKMPMoviePlaybackStateInitialized:
+                case IJKMPMoviePlaybackStateAsyncPreparing:
                 case IJKMPMoviePlaybackStatePaused:
                 case IJKMPMoviePlaybackStateStopped:
                 case IJKMPMoviePlaybackStateCompleted:

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -1205,7 +1205,10 @@ inline static void fillMetaInternal(NSMutableDictionary *meta, IjkMediaMeta *raw
         case FFP_MSG_BUFFERING_UPDATE:
             _bufferingPosition = avmsg->arg1;
             _bufferingProgress = avmsg->arg2;
-            // NSLog(@"FFP_MSG_BUFFERING_UPDATE: %d, %%%d\n", _bufferingPosition, _bufferingProgress);
+            NSLog(@"FFP_MSG_BUFFERING_UPDATE: %d, %%%d\n", _bufferingPosition, _bufferingProgress);
+            [[NSNotificationCenter defaultCenter]
+             postNotificationName:IJKMPMovieBufferingPositionDidChangeNotification
+             object:self];
             break;
         case FFP_MSG_BUFFERING_BYTES_UPDATE:
             // NSLog(@"FFP_MSG_BUFFERING_BYTES_UPDATE: %d\n", avmsg->arg1);

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -669,7 +669,17 @@ inline static int getPlayerOption(IJKFFOptionCategory category)
      object:self];
 
     _bufferingPosition = 0;
-    ijkmp_seek_to(_mediaPlayer, aCurrentPlaybackTime * 1000);
+    int retVal = ijkmp_seek_to(_mediaPlayer, aCurrentPlaybackTime * 1000);
+    
+    // ijkmp_seek_to can immediately fail, retVal contains the error code
+    if (retVal != 0) {
+        [self.videoPlaybackNotificationCenter
+         postNotificationName:IJKMPMoviePlayerDidSeekCompleteNotification
+         object:self
+         userInfo:@{IJKMPMoviePlayerDidSeekCompleteTargetKey: @(aCurrentPlaybackTime * 1000),
+                    IJKMPMoviePlayerDidSeekCompleteErrorKey: @(retVal)}];
+        _seeking = NO;
+    }
 }
 
 - (NSTimeInterval)currentPlaybackTime

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -37,7 +37,10 @@ typedef NS_CLOSED_ENUM(NSInteger, IJKMPMoviePlaybackState) {
     IJKMPMoviePlaybackStatePaused,
     IJKMPMoviePlaybackStateInterrupted,
     IJKMPMoviePlaybackStateSeekingForward,
-    IJKMPMoviePlaybackStateSeekingBackward
+    IJKMPMoviePlaybackStateSeekingBackward,
+    IJKMPMoviePlaybackStateCompleted,
+    IJKMPMoviePlaybackStateError,
+    IJKMPMoviePlaybackStateEnd
 };
 
 typedef NS_OPTIONS(NSUInteger, IJKMPMovieLoadState) {

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -138,11 +138,16 @@ IJK_EXTERN NSString* const IJKMPMoviePlayerLoadStateDidChangeNotification;
 // Posted when the movie player begins or ends playing video via AirPlay.
 IJK_EXTERN NSString* const IJKMPMoviePlayerIsAirPlayVideoActiveDidChangeNotification;
 
+// Posted when the buffering position of movie player changes.
+IJK_EXTERN NSString* const IJKMPMovieBufferingPositionDidChangeNotification;
+
 // -----------------------------------------------------------------------------
 // Movie Property Notifications
 
 // Calling -prepareToPlay on the movie player will begin determining movie properties asynchronously.
 // These notifications are posted when the associated movie property becomes available.
+
+// Posted when the natural size of movie player changes
 IJK_EXTERN NSString* const IJKMPMovieNaturalSizeAvailableNotification;
 
 // -----------------------------------------------------------------------------

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -40,7 +40,10 @@ typedef NS_CLOSED_ENUM(NSInteger, IJKMPMoviePlaybackState) {
     IJKMPMoviePlaybackStateSeekingBackward,
     IJKMPMoviePlaybackStateCompleted,
     IJKMPMoviePlaybackStateError,
-    IJKMPMoviePlaybackStateEnd
+    IJKMPMoviePlaybackStateEnd,
+    IJKMPMoviePlaybackStateIdle,
+    IJKMPMoviePlaybackStateInitialized,
+    IJKMPMoviePlaybackStateAsyncPreparing
 };
 
 typedef NS_OPTIONS(NSUInteger, IJKMPMovieLoadState) {

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.h
@@ -24,14 +24,14 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-typedef NS_ENUM(NSInteger, IJKMPMovieScalingMode) {
+typedef NS_CLOSED_ENUM(NSInteger, IJKMPMovieScalingMode) {
     IJKMPMovieScalingModeNone,       // No scaling
     IJKMPMovieScalingModeAspectFit,  // Uniform scale until one dimension fits
     IJKMPMovieScalingModeAspectFill, // Uniform scale until the movie fills the visible bounds. One dimension may have clipped contents
     IJKMPMovieScalingModeFill        // Non-uniform scale. Both render dimensions will exactly match the visible bounds
 };
 
-typedef NS_ENUM(NSInteger, IJKMPMoviePlaybackState) {
+typedef NS_CLOSED_ENUM(NSInteger, IJKMPMoviePlaybackState) {
     IJKMPMoviePlaybackStateStopped,
     IJKMPMoviePlaybackStatePlaying,
     IJKMPMoviePlaybackStatePaused,
@@ -47,7 +47,7 @@ typedef NS_OPTIONS(NSUInteger, IJKMPMovieLoadState) {
     IJKMPMovieLoadStateStalled        = 1 << 2, // Playback will be automatically paused in this state, if started
 };
 
-typedef NS_ENUM(NSInteger, IJKMPMovieFinishReason) {
+typedef NS_CLOSED_ENUM(NSInteger, IJKMPMovieFinishReason) {
     IJKMPMovieFinishReasonPlaybackEnded,
     IJKMPMovieFinishReasonPlaybackError,
     IJKMPMovieFinishReasonUserExited
@@ -56,7 +56,7 @@ typedef NS_ENUM(NSInteger, IJKMPMovieFinishReason) {
 // -----------------------------------------------------------------------------
 // Thumbnails
 
-typedef NS_ENUM(NSInteger, IJKMPMovieTimeOption) {
+typedef NS_CLOSED_ENUM(NSInteger, IJKMPMovieTimeOption) {
     IJKMPMovieTimeOptionNearestKeyFrame,
     IJKMPMovieTimeOptionExact
 };

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKMediaPlayback.m
@@ -33,6 +33,8 @@ NSString *const IJKMPMoviePlayerLoadStateDidChangeNotification = @"IJKMPMoviePla
 
 NSString *const IJKMPMoviePlayerIsAirPlayVideoActiveDidChangeNotification = @"IJKMPMoviePlayerIsAirPlayVideoActiveDidChangeNotification";
 
+NSString* const IJKMPMovieBufferingPositionDidChangeNotification = @"IJKMPMovieBufferingTimeDidChangeNotification";
+
 NSString *const IJKMPMovieNaturalSizeAvailableNotification = @"IJKMPMovieNaturalSizeAvailableNotification";
 
 NSString *const IJKMPMoviePlayerVideoDecoderOpenNotification = @"IJKMPMoviePlayerVideoDecoderOpenNotification";

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKNotificationManager.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKNotificationManager.h
@@ -25,7 +25,7 @@
 
 @interface IJKNotificationManager : NSObject
 
-- (nullable instancetype)init;
+- (instancetype)init;
 
 - (void)addObserver:(nonnull id)observer
            selector:(nonnull SEL)aSelector

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKNotificationManager.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKNotificationManager.h
@@ -23,6 +23,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface IJKNotificationManager : NSObject
 
 - (instancetype)init;
@@ -35,3 +37,5 @@
 - (void)removeAllObservers:(nonnull id)observer;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKSDLGLViewProtocol.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKSDLGLViewProtocol.h
@@ -39,6 +39,34 @@ struct IJKOverlay {
     CVPixelBufferRef pixel_buffer;
 };
 
+/// A protocol to guarantee that non-thread safe values are accessed from
+/// an object that can guarantee thread safety.
+/// IJKFFMovieController and IJKSDLGLView will access non-thread safe
+/// values from a background thread. The object that conforms to this protocol
+/// should safely handle the access of these properties, internally setting them on main thread.
+@protocol IJKThreadSafeMainScreen
+
+/// Returns the current bounds of the screen
+@property (readonly) CGRect bounds;
+
+/// Returns the current scale of the screen
+@property (readonly) CGFloat scale;
+
+@end
+
+/// A protocol to guarantee that non-thread safe values are accessed from
+/// an object that can guarantee thread safety.
+/// IJKFFMovieController and IJKSDLGLView will access non-thread safe
+/// values from a background thread. The object that conforms to this protocol
+/// should safely handle the access of these properties, internally setting them on main thread.
+@protocol IJKThreadSafeApplicationState
+
+/// Returns the current state of the application
+@property (readonly) UIApplicationState applicationState;
+
+@end
+
+
 @protocol IJKSDLGLViewProtocol <NSObject>
 - (UIImage*) snapshot;
 @property(nonatomic, readonly) CGFloat  fps;

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.h
@@ -30,7 +30,16 @@
 
 @interface IJKSDLGLView : UIView <IJKSDLGLViewProtocol>
 
-- (id) initWithFrame:(CGRect)frame;
+
+/// Initialization method for IJKSDLGLView (a wrapper for OpenGL layer CAEAGLLayer)
+/// - Parameters:
+///   - frame: the expected frame for the view
+///   - mainScreen: a thread safe wrapper that provides access to values from UIScreen.mainScreen
+///   - application: a thread safe wrapper that provides access to values from UIApplication.sharedApplication
+- (id) initWithFrame:(CGRect)frame
+withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
+withApplicationStateProvider:(id<IJKThreadSafeApplicationState>)applicationStateProvider;
+
 - (void) display: (SDL_VoutOverlay *) overlay;
 
 - (UIImage*) snapshot;


### PR DESCRIPTION
## Summary
- Surface buffering updates with Notifications 
- Replace NotificationCenter with dependency injection 
- Use NS_CLOSED_ENUM instead of NS_ENUM 
- Add NS_ASSUME_NONNULL to IJKFFMoviePlayerController.h 
- Post notification when ijkmp_seek_to fails immediately 
- Decouple video player from idleTimerDisabled 
- Expand IJKMPMoviePlaybackState to differentiate Stopped, Completed, Error, End
- Remove shouldAutoplay hardcoded to yes 
- Split up IJKMPMoviePlaybackState to get more granularity 
- Fix warning for IJKNotificationManager 
- Inject thread safe value provider into ijkplayer