### PR TITLE
make some ijk code background thread safe

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKSDLGLViewProtocol.h
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKSDLGLViewProtocol.h
@@ -72,6 +72,7 @@ struct IJKOverlay {
 @property(nonatomic, readonly) CGFloat  fps;
 @property(nonatomic)        CGFloat  scaleFactor;
 @property(nonatomic)        BOOL  isThirdGLView;
+@property(nonatomic) CALayer *glLayer;
 - (void) display_pixels: (IJKOverlay *) overlay;
 @end
 

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipenode_ios_videotoolbox_vdec.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijkplayer/ios/pipeline/ffpipenode_ios_videotoolbox_vdec.m
@@ -101,8 +101,7 @@ IJKFF_Pipenode *ffpipenode_create_video_decoder_from_ios_videotoolbox(FFPlayer *
     IJKFF_Pipenode *node = ffpipenode_alloc(sizeof(IJKFF_Pipenode_Opaque));
     if (!node)
         return node;
-    memset(node, sizeof(IJKFF_Pipenode), 0);
-
+    
     VideoState            *is         = ffp->is;
     IJKFF_Pipenode_Opaque *opaque     = node->opaque;
     node->func_destroy  = func_destroy;

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
@@ -150,6 +150,11 @@ withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
     return YES;
 }
 
+- (CALayer *)glLayer
+{
+    return _eaglLayer;
+}
+
 - (BOOL)setupGL
 {
     if (_didSetupGL)
@@ -644,6 +649,7 @@ withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
 {
     _shouldLockWhileBeingMovedToWindow = shouldLockWhileBeingMovedToWindow;
 }
+
 @end
 
 

--- a/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m
@@ -34,6 +34,8 @@ typedef NS_ENUM(NSInteger, IJKSDLGLViewApplicationState) {
     IJKSDLGLViewApplicationBackgroundState = 2
 };
 
+static void IJK_dispatch_block_on_main_thread(dispatch_block_t block);
+
 @interface IJKSDLGLView()
 @property(atomic,strong) NSRecursiveLock *glActiveLock;
 @property(atomic) BOOL glActivePaused;
@@ -65,6 +67,8 @@ typedef NS_ENUM(NSInteger, IJKSDLGLViewApplicationState) {
     NSMutableArray *_registeredNotifications;
 
     IJKSDLGLViewApplicationState _applicationState;
+    
+    CAEAGLLayer *_eaglLayer;
 }
 
 @synthesize isThirdGLView              = _isThirdGLView;
@@ -126,7 +130,7 @@ withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
     glGenRenderbuffers(1, &_renderbuffer);
     glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
     glBindRenderbuffer(GL_RENDERBUFFER, _renderbuffer);
-    [_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer*)self.layer];
+    [_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:_eaglLayer];
     glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &_backingWidth);
     glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &_backingHeight);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, _renderbuffer);
@@ -146,17 +150,12 @@ withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
     return YES;
 }
 
-- (CAEAGLLayer *)eaglLayer
-{
-    return (CAEAGLLayer*) self.layer;
-}
-
 - (BOOL)setupGL
 {
     if (_didSetupGL)
         return YES;
 
-    CAEAGLLayer *eaglLayer = (CAEAGLLayer*) self.layer;
+    CAEAGLLayer *eaglLayer = _eaglLayer;
     eaglLayer.opaque = YES;
     eaglLayer.drawableProperties = [NSDictionary dictionaryWithObjectsAndKeys:
                                     [NSNumber numberWithBool:NO], kEAGLDrawablePropertyRetainedBacking,
@@ -196,6 +195,10 @@ withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
     if (![self tryLockGLActive])
         return NO;
 
+    IJK_dispatch_block_on_main_thread(^{
+        _eaglLayer = (CAEAGLLayer*) self.layer;
+    });
+    
     BOOL didSetupGL = [self setupGL];
     [self unlockGLActive];
     return didSetupGL;
@@ -377,14 +380,14 @@ withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
         return;
     }
 
-    [[self eaglLayer] setContentsScale:_scaleFactor];
+    [_eaglLayer setContentsScale:_scaleFactor];
 
     if (_isRenderBufferInvalidated) {
         NSLog(@"IJKSDLGLView: renderbufferStorage fromDrawable\n");
         _isRenderBufferInvalidated = NO;
 
         glBindRenderbuffer(GL_RENDERBUFFER, _renderbuffer);
-        [_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer*)self.layer];
+        [_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:_eaglLayer];
         glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &_backingWidth);
         glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &_backingHeight);
         IJK_GLES2_Renderer_setGravity(_renderer, _rendererGravity, _backingWidth, _backingHeight);
@@ -642,3 +645,18 @@ withMainScreenProvider:(id<IJKThreadSafeMainScreen>)mainScreenProvider
     _shouldLockWhileBeingMovedToWindow = shouldLockWhileBeingMovedToWindow;
 }
 @end
+
+
+#pragma mark - private
+
+static void IJK_dispatch_block_on_main_thread(dispatch_block_t block)
+{
+    NSCParameterAssert(block != nil);
+    if (block) {
+        if ([NSThread isMainThread]) {
+            block();
+        } else {
+            dispatch_sync(dispatch_get_main_queue(), block);
+        }
+    }
+}


### PR DESCRIPTION
this is part of effort to make ijkplayer able to initialize and use in background thread.

**There is crash report by Rahul R** (even though I was never able to reproduce):
```
heyo if i scroll long enough on search results on simulator, i'm pretty cnosistently getting `EXC_BAD_ACCESS in some open gl renderer stuff, there's things like IJKSDLGLView in the console log (edited) 
3:18
is this a known video issue by chance?
3:19
e.g.
Enqueued from com.apple.root.default-qos.overcommit (Thread 170) Queue : com.apple.root.default-qos.overcommit (serial)
#0	0x0000000114575570 in _dispatch_async_f_slow ()
#1	0x0000000130cc1a84 in gleSetVPTransformFuncAll ()
#2	0x0000000130cbcd24 in gleLLVMVecPrimMultiRender ()
#3	0x0000000130c593c0 in glDrawArrays_ES2Exec ()
#4	0x0000000113ec8b88 in IJK_GLES2_Renderer_renderOverlay at /Users/lma/code/ijk_pins/ijkmedia/ijksdl/gles2/renderer.c:426
#5	0x0000000113ec690c in -[IJKSDLGLView displayInternal:] at /Users/lma/code/ijk_pins/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m:396
#6	0x0000000113ec671c in -[IJKSDLGLView display:] at /Users/lma/code/ijk_pins/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/IJKSDLGLView.m:361
#7	0x0000000113ed96e8 in vout_display_overlay_l [inlined] at /Users/lma/code/ijk_pins/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/ijksdl_vout_ios_gles2.m:116
#8	0x0000000113ed9674 in vout_display_overlay at /Users/lma/code/ijk_pins/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/ijksdl_vout_ios_gles2.m:125
#9	0x0000000113ec1ea0 in video_image_display2 [inlined] at /Users/lma/code/ijk_pins/ijkmedia/ijkplayer/ff_ffplay.c:911
#10	0x0000000113ec1db0 in video_display2 at /Users/lma/code/ijk_pins/ijkmedia/ijkplayer/ff_ffplay.c:1069
#11	0x0000000113ec0144 in video_refresh [inlined] at /Users/lma/code/ijk_pins/ijkmedia/ijkplayer/ff_ffplay.c:1416
#12	0x0000000113ebfaf8 in video_refresh_thread at /Users/lma/code/ijk_pins/ijkmedia/ijkplayer/ff_ffplay.c:3771
#13	0x0000000113ec40c8 in SDL_RunThread at /Users/lma/code/ijk_pins/ios/IJKMediaPlayer/IJKMediaPlayer/ijkmedia/ijksdl/ios/ijksdl_thread_ios.m:32
#14	0x00000001bca44428 in _pthread_start ()
#15	0x00000001bca3f648 in thread_start ()
```


and **main thread checker waring**:
```
Main Thread Checker: UI API called on a background thread: -[UIView layer]
PID: 68991, TID: 21700745, Thread name: ff_vout, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4  IJKMediaFramework          0x000000011126a80c -[IJKSDLGLView displayInternal:] + 48
5  IJKMediaFramework          0x000000011126a74c -[IJKSDLGLView display:] + 160
6  IJKMediaFramework          0x000000011127d688 vout_display_overlay + 280
7  IJKMediaFramework          0x0000000111265ed0 video_display2 + 352
8  IJKMediaFramework          0x0000000111264174 video_refresh_thread + 1892
9  IJKMediaFramework          0x00000001112680f8 SDL_RunThread + 40
10 libsystem_pthread.dylib       0x00000001b059e428 _pthread_start + 116
11 libsystem_pthread.dylib       0x00000001b0599648 thread_start + 8
2023-09-01 13:41:33.928819-0700 PinterestDevelopment[68991:21700745] [reports] Main Thread Checker: UI API called on a background thread: -[UIView layer]
PID: 68991, TID: 21700745, Thread name: ff_vout, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
```
