### PR TITLE
call setupAudioSession only when its about to play and volume > 0

### DIFF
--- a/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
+++ b/ios/IJKMediaPlayer/IJKMediaPlayer/IJKFFMoviePlayerController.m
@@ -279,8 +279,8 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 #else
         [IJKFFMoviePlayerController setLogLevel:k_IJK_LOG_SILENT];
 #endif
-        // init audio sink
-        [[IJKAudioKit sharedInstance] setupAudioSession];
+        // init audio sink; lma: disable here as it would  intrupt background audio even current video doesn't play or is muted. Moved to -play
+      //  [[IJKAudioKit sharedInstance] setupAudioSession];
 
         [options applyTo:_mediaPlayer];
         _pauseInBackground = NO;
@@ -416,7 +416,6 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 {
     if (!_mediaPlayer)
         return;
-
     ijkmp_set_data_source(_mediaPlayer, [_urlString UTF8String]);
     ijkmp_set_option(_mediaPlayer, IJKMP_OPT_CATEGORY_FORMAT, "safe", "0"); // for concat demuxer
 
@@ -442,6 +441,10 @@ void IJKFFIOStatCompleteRegister(void (*cb)(const char *url,
 {
     if (!_mediaPlayer)
         return;
+    
+    if ([self playbackVolume] > 0) {
+        [[IJKAudioKit sharedInstance] setupAudioSession];
+    }
 
     [self startHudTimer];
     ijkmp_start(_mediaPlayer);


### PR DESCRIPTION
Previously ` [[IJKAudioKit sharedInstance] setupAudioSession]` is called on every player instantiation, so no matter if video is being played or muted(volume:no), the audio session will be set up and mute all the background audio, which is a bad user experience.

The change is to defer it until -play() and checks volume (this needs to be revisited as I am not very sure what if video started as muted then increase volume while video plays) as well 